### PR TITLE
Force rounding down when unwrapping WETH

### DIFF
--- a/site/pages/_app.js
+++ b/site/pages/_app.js
@@ -1,9 +1,14 @@
 import '../styles/index.css'
 import { Web3ReactProvider } from '@web3-react/core'
+import Big from 'big.js'
 import Web3 from 'web3'
 import { PureContextProvider } from '../components/context/Pure'
 
 const getLibrary = (provider) => new Web3(provider)
+
+// Force Big to round down.
+// See https://github.com/MikeMcl/big.js/blob/v5.2.2/big.js#L26
+Big.RM = 0
 
 function App({ Component, pageProps }) {
   return (


### PR DESCRIPTION
## Description

Due to rounding when using a large number of decimals, in some scenarios the unwrap button was disabled. This PR forces rounding down in all the applications (which will be useful for future apps too)

## Related Issue

closes #36 