### PR TITLE
Fix the sorting of the auctions table

### DIFF
--- a/site/pages/dp-auctions/collections/[collectionId].js
+++ b/site/pages/dp-auctions/collections/[collectionId].js
@@ -69,7 +69,7 @@ const DPAuctionsTable = function ({ auctions }) {
   const sortedAuctions = orderBy(
     auctions.filter((auction) => showEnded || !auction.stopped),
     ['endBlock', 'id'],
-    ['desc', 'desc']
+    ['asc', 'desc']
   )
 
   return (


### PR DESCRIPTION
The default sorting of auctions in the DPA mini-app was wrong. This PR applies the proper sorting: auctions ending sooner first.

### Metrics

Actual effort: 0.5h