### PR TITLE
Prevent prod-only builds to crash

### DIFF
--- a/packages/payment-streams/package.json
+++ b/packages/payment-streams/package.json
@@ -11,7 +11,7 @@
   "repository": "purefinance/pure.finance",
   "scripts": {
     "deps:check": "dependency-check --no-dev .",
-    "postinstall": "patch-package",
+    "postinstall": "patch-package || true",
     "test:e2e": "DEBUG=*,-mocha*,-babel* DEBUG_COLORS=true E2E=true FORCE_COLOR=true mocha --bail --exit test/e2e.spec.js",
     "coverage:e2e": "nyc npm run test:e2e"
   },


### PR DESCRIPTION
This PR fixes a problem with #71 where prod-only builds crash when trying to run `patch-package`.

### Metrics

Actual effort: 0.5h