### PR TITLE
Prevent prod-only builds to crash again

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "dev": "concurrently --kill-others --names \"Fork,Next\" \"node utils/fork.js\" \"next dev\"",
     "deps:check": "dependency-check --detective precinct --ignore-module autoprefixer --ignore-module patch-package --ignore-module react-dom --ignore-module tailwindcss --ignore-module next-secure-headers --no-dev ./pages/*.js ./pages/*/*.js ./pages/*/*/*.js",
-    "postinstall": "patch-package",
+    "postinstall": "patch-package || true",
     "prestart": "npm run build",
     "start": "next start"
   },


### PR DESCRIPTION
This PR continues with an additional fix on top of #81 where prod-only builds crash when trying to run patch-package.
