### PR TITLE
Use web3.eth.personal to sign messages

### DIFF
--- a/site/pages/sign-message.js
+++ b/site/pages/sign-message.js
@@ -49,15 +49,16 @@ const SignMessageForm = function () {
   const signButton = {
     disabled: !active || !message,
     onClick() {
-      web3.eth.sign(message, account, function (err, _signature) {
-        if (err) {
+      web3.eth.personal
+        .sign(message, account)
+        .then(function (_signature) {
+          setSignature(_signature)
+          setFeedback('success', 'Signed successfully')
+        })
+        .catch(function (err) {
           setSignature()
           setFeedback('error', err.message)
-          return
-        }
-        setSignature(_signature)
-        setFeedback('success', 'Signed successfully')
-      })
+        })
     }
   }
 


### PR DESCRIPTION
## Summary

Changes the function used to sign messages from `web3.eth.sign()` to `web3.eth.personal.sign()` as the former has issues with some wallets combinations like MetaMask + Ledger.

## Related Issue

#85 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Metrics

Actual effort 0.5h