### PR TITLE
Set the claim id from the querystring on load

### DIFF
--- a/site/pages/merkle-claims.js
+++ b/site/pages/merkle-claims.js
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useEffect, useState } from 'react'
 import debounce from 'lodash.debounce'
+import { useRouter } from 'next/router'
 import useTranslation from 'next-translate/useTranslation'
 import { useWeb3React } from '@web3-react/core'
 import watchAsset from 'wallet-watch-asset'
@@ -13,6 +14,7 @@ import PureContext from '../components/context/Pure'
 function MerkleClaims() {
   const { t } = useTranslation('common')
   const { active, account } = useWeb3React()
+  const { query } = useRouter()
   const [claimID, setClaimID] = useState('')
   const [claimInProgress, setClaimInProgress] = useState(false)
   const [holding, setHolding] = useState({ amount: '', isClaimable: false })
@@ -27,10 +29,11 @@ function MerkleClaims() {
   const setSuccessMessage = message =>
     setFeedback({ color: 'text-green-600', message })
 
-  const getHolding = claimID =>
-    claimID &&
+  const getHolding = cID =>
+    cID &&
+    merkle.getHolding &&
     merkle
-      .getHolding(claimID)
+      .getHolding(cID)
       .then(h => {
         if (h.isClaimable) {
           clearFeedback()
@@ -75,6 +78,13 @@ function MerkleClaims() {
   }, [active, account])
 
   useEffect(() => setHolding({ amount: '', isClaimable: false }), [claimID])
+
+  useEffect(
+    function setClaimIdFromQueryOnLoad() {
+      handleClaimIDChange({ target: { value: query.id } })
+    },
+    [merkle, query]
+  )
 
   return (
     <Layout title={t('merkle-claims')} walletConnection>


### PR DESCRIPTION
## Summary

<!--- Provide a general summary of your changes in the Title above -->

This PR allows setting the Merkle chaim group ID through the page querystring. I.e. the following URL will automatically set claim id 60 in the input:

https://pure.finance/merkle-claims?id=60 

PD: Changes in the input should also update the URL but that can be done in another PR :) 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual tests show everything works!

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
