### PR TITLE
Add verification links to sign message app

### DIFF
--- a/site/locales/en/common.json
+++ b/site/locales/en/common.json
@@ -104,6 +104,8 @@
   "unwrap": "unwrap",
   "utilties": "Utilities",
   "value": "Value",
+  "verify-signature-etherscan": "Verify signature on Etherscan",
+  "view-source-code": "View source code",
   "winning-price": "Winning price",
   "won-by": "Won by",
   "won": "Won",

--- a/site/locales/zh/common.json
+++ b/site/locales/zh/common.json
@@ -102,6 +102,8 @@
   "unwrap": "解封",
   "utilties": "工具",
   "value": "价值",
+  "verify-signature-etherscan": "Verify signature on Etherscan",
+  "view-source-code": "View source code",
   "winning-price": "中奖价格",
   "won-by": "赢了",
   "won": "韩元",

--- a/site/pages/sign-message.js
+++ b/site/pages/sign-message.js
@@ -86,6 +86,24 @@ const SignMessageForm = function () {
       <p className={`text-center text-sm mt-6 ${feedback.color}`}>
         {feedback.message}
       </p>
+      <div className="flex justify-between mx-auto w-full max-w-lg">
+        <a
+          className="hover:text-black text-gray-400 focus:outline-none"
+          href="https://github.com/purefinance/pure.finance/blob/master/site/pages/sign-message.js"
+          rel="noreferrer"
+          target="_blank"
+        >
+          {t('view-source-code')}
+        </a>
+        <a
+          className="hover:text-black text-gray-400 focus:outline-none"
+          href="https://etherscan.io/verifiedSignatures"
+          rel="noreferrer"
+          target="_blank"
+        >
+          {t('verify-signature-etherscan')}
+        </a>
+      </div>
     </>
   )
 }


### PR DESCRIPTION
## Summary
This PR adds verification links to sign message app

## Related Issue
Closes #90

## Screenshots:
<img width="719" alt="image" src="https://user-images.githubusercontent.com/20405533/199355888-a28d858a-dd98-4625-9cc7-9a87136c4961.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
