### PR TITLE
Use 404 to redirect to localized paths

### DIFF
--- a/site/pages/404.js
+++ b/site/pages/404.js
@@ -1,0 +1,45 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+
+const DEFAULT_LOCALE = 'en'
+
+/* eslint-disable sort-keys */
+const states = {
+  loading: 0,
+  redirecting: 1,
+  prefixed: 2
+}
+/* eslint-enable sort-keys */
+
+export default function LocalizedRedirectHandler() {
+  const router = useRouter()
+
+  const [state, setState] = useState(states.loading)
+
+  useEffect(
+    function redirectIfNotLocalized() {
+      if (typeof window === 'undefined') {
+        return
+      }
+
+      const path = window.location.pathname
+      if (path.startsWith(`/${DEFAULT_LOCALE}/`)) {
+        setState(states.prefixed)
+      } else {
+        setState(states.redirecting)
+        router.replace(`/${DEFAULT_LOCALE}${path}`)
+      }
+    },
+    [router]
+  )
+
+  return (
+    <div className="bg-grayscale-50 flex min-h-screen items-center justify-center text-center">
+      {state === states.loading ? null : state === states.redirecting ? (
+        <p>Redirecting...</p>
+      ) : (
+        <p>404 | This page could not be found</p>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
By modifying the 404 page, non-localized paths can be redirected to localized paths.

This will affect SEO but is not a big deal for PF. In the case we realize it is, then another approach using GetStaticPaths could be implemented.